### PR TITLE
Update domain file to 2.8

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -41,7 +41,7 @@ slots:
     type: text
     influence_conversation: false
   requested_slot:
-    type: unfeaturized
+    type: any
     influence_conversation: false
   verified_email:
     type: bool
@@ -169,35 +169,41 @@ actions:
 - action_give_name
 forms:
   order_status_form:
-    email:
-    - entity: email
-      type: from_entity
-    - intent:
-      - inform
-      type: from_text
+    required_slots:
+      email:
+      - entity: email
+        type: from_entity
+      - intent:
+        - inform
+        type: from_text
   cancel_form:
-    email:
-    - entity: email
-      type: from_entity
+    required_slots:
+      email:
+      - entity: email
+        type: from_entity
   return_form:
-    email:
-    - entity: email
-      not_intent: product_updates
-      type: from_entity
+    required_slots:
+      email:
+      - entity: email
+        not_intent: product_updates
+        type: from_entity
   product_updates_form:
-    email:
-    - entity: email
-      type: from_entity
+    required_slots:
+      email:
+      - entity: email
+        type: from_entity
   product_stock_form:
-    size:
-    - entity: number
-      type: from_entity
-    color:
-    - entity: color
-      type: from_entity
+    required_slots:
+      size:
+      - entity: number
+        type: from_entity
+      color:
+      - entity: color
+        type: from_entity
   survey_form:
-    rating:
-    - entity: number
-      type: from_entity
-    open_feedback:
-    - type: from_text
+    required_slots:
+      rating:
+      - entity: number
+        type: from_entity
+      open_feedback:
+      - type: from_text


### PR DESCRIPTION
The research team [wants to add this repo to the core policy regression tests](https://github.com/RasaHQ/rasa/issues/8676). To do that we need to update the domain file to be compatible with Rasa 2.8.

Currently the form definitions in the domain.yml do not use the `required_slots` key. Not using the key was marked as deprecated in Rasa 2.6. As we move to 3.0 and start removing deprecated behaviors, not using the `required_slots` keys will cause training to fail on YAML validation.

This PR adds the `required_slots` key to all form definitions in the domain.yml. This should not change the behavior of the bot.